### PR TITLE
Fix: Webhook events

### DIFF
--- a/conekta_prestashop.php
+++ b/conekta_prestashop.php
@@ -809,7 +809,7 @@ class Conekta_Prestashop extends PaymentModule
 
         $events = array(
             "events" => array(
-                "charge.paid"
+                "order.paid"
                 )
             );
 
@@ -976,6 +976,7 @@ class Conekta_Prestashop extends PaymentModule
             $state,
             $country
         );
+        $order_details['metadata'] = array("reference_id" => $this->context->cart->id);
 
         $amount = 0;
 


### PR DESCRIPTION
**Why is this change neccesary?**
This change is a bug fix that fixes this issue https://github.com/conekta/conektaprestashop/issues/51#issuecomment-319850128
**How does it address the issue?**
* change webhook creating from ccharge.paid (version 1.0.0) to order.paid (version 2.0.0)
* Putting metadata in order details because is used at webhook code in order to change prestashop order status 

**What side effects does this change have?**
nothing, better user experience

